### PR TITLE
updating config for pipeline builds adding versioning to dockerfiles

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ FROM lsiobase/alpine:3.8
 # set version label
 ARG BUILD_DATE
 ARG VERSION
+ARG LDAP_VERSION
 LABEL build_version="Linuxserver.io version:- ${VERSION} Build-date:- ${BUILD_DATE}"
 LABEL maintainer="aptalca"
 
@@ -19,9 +20,14 @@ RUN \
 	libldap \
 	py2-pip \
 	python2 && \
+ if [ -z ${LDAP_VERSION+x} ]; then \
+  LDAP_INSTALL="python-ldap"; \
+ else \
+  LDAP_INSTALL="python-ldap==${LDAP_VERSION}"; \
+ fi && \
  pip install -U --no-cache-dir \
 	cryptography \
-	python-ldap && \
+	${LDAP_INSTALL} && \
  echo "**** cleanup ****" && \
  apk del --purge \
 	build-dependencies && \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -1,8 +1,12 @@
 FROM lsiobase/alpine.arm64:3.8
 
+# Add qemu to run on x86_64 systems
+COPY qemu-aarch64-static /usr/bin
+
 # set version label
 ARG BUILD_DATE
 ARG VERSION
+ARG LDAP_VERSION
 LABEL build_version="Linuxserver.io version:- ${VERSION} Build-date:- ${BUILD_DATE}"
 LABEL maintainer="aptalca"
 
@@ -19,9 +23,14 @@ RUN \
 	libldap \
 	py2-pip \
 	python2 && \
+ if [ -z ${LDAP_VERSION+x} ]; then \
+  LDAP_INSTALL="python-ldap"; \
+ else \
+  LDAP_INSTALL="python-ldap==${LDAP_VERSION}"; \
+ fi && \
  pip install -U --no-cache-dir \
 	cryptography \
-	python-ldap && \
+	${LDAP_INSTALL} && \
  echo "**** cleanup ****" && \
  apk del --purge \
 	build-dependencies && \

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -1,8 +1,12 @@
 FROM lsiobase/alpine.armhf:3.8
 
+# Add qemu to run on x86_64 systems
+COPY qemu-arm-static /usr/bin
+
 # set version label
 ARG BUILD_DATE
 ARG VERSION
+ARG LDAP_VERSION
 LABEL build_version="Linuxserver.io version:- ${VERSION} Build-date:- ${BUILD_DATE}"
 LABEL maintainer="aptalca"
 
@@ -19,9 +23,14 @@ RUN \
 	libldap \
 	py2-pip \
 	python2 && \
+ if [ -z ${LDAP_VERSION+x} ]; then \
+  LDAP_INSTALL="python-ldap"; \
+ else \
+  LDAP_INSTALL="python-ldap==${LDAP_VERSION}"; \
+ fi && \
  pip install -U --no-cache-dir \
 	cryptography \
-	python-ldap && \
+	${LDAP_INSTALL} && \
  echo "**** cleanup ****" && \
  apk del --purge \
 	build-dependencies && \


### PR DESCRIPTION
Adding the qemu bins to the dockerfile and an if statement to accept the pip version for pipe builds and use latest for users pulling and building manually. 

The Readme update logic needs to be directly commited to this repository under the current design: 
https://github.com/linuxserver/doc-builder

The "CONTAINER_NAME" variable is just passed to the container built by this repo, I pulled it out of the JenkinsFile which will prevent this logic from running. Once it is in the centralized readme repo this variable can be added back in. 