### PR TITLE
need a cache directory for cryptography install on current pip version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,15 +26,16 @@ RUN \
   LDAP_INSTALL="python-ldap==${LDAP_VERSION}"; \
  fi && \
  pip install -U --no-cache-dir \
- 	pip && \
- pip install -U --no-cache-dir \
-	cryptography \
-	${LDAP_INSTALL} && \
+        pip && \
+ pip install -U \
+        cryptography \
+        ${LDAP_INSTALL} && \
  echo "**** cleanup ****" && \
  apk del --purge \
-	build-dependencies && \
+        build-dependencies && \
  rm -rf \
-	/tmp/*
+        /tmp/* \
+        /root/.cache/pip
 
 # copy local files
 COPY root/ /

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -29,15 +29,16 @@ RUN \
   LDAP_INSTALL="python-ldap==${LDAP_VERSION}"; \
  fi && \
  pip install -U --no-cache-dir \
- 	pip && \
- pip install -U --no-cache-dir \
-	cryptography \
-	${LDAP_INSTALL} && \
+        pip && \
+ pip install -U \
+        cryptography \
+        ${LDAP_INSTALL} && \
  echo "**** cleanup ****" && \
  apk del --purge \
-	build-dependencies && \
+        build-dependencies && \
  rm -rf \
-	/tmp/*
+        /tmp/* \
+        /root/.cache/pip
 
 # copy local files
 COPY root/ /

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -29,15 +29,16 @@ RUN \
   LDAP_INSTALL="python-ldap==${LDAP_VERSION}"; \
  fi && \
  pip install -U --no-cache-dir \
- 	pip && \
- pip install -U --no-cache-dir \
-	cryptography \
-	${LDAP_INSTALL} && \
+        pip && \
+ pip install -U \
+        cryptography \
+        ${LDAP_INSTALL} && \
  echo "**** cleanup ****" && \
  apk del --purge \
-	build-dependencies && \
+        build-dependencies && \
  rm -rf \
-	/tmp/*
+        /tmp/* \
+        /root/.cache/pip
 
 # copy local files
 COPY root/ /


### PR DESCRIPTION
Pulling this to fix current state at head of the build. 
We need the cache directory it looks like for version 19 of pip. 