### PR TITLE
Update nginx-ldap-auth-daemon.py

### DIFF
--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -34,6 +34,7 @@ app_setup_block: |
 
 # changelog
 changelogs:
+  - { date: "20.08.20:", desc: "Add support for self-signed CA certs." }
   - { date: "20.02.20:", desc: "Switch to python3." }
   - { date: "19.12.19:", desc: "Rebasing to alpine 3.11." }
   - { date: "01.07.19:", desc: "Fall back to base64 encoding when basic http auth is used." }

--- a/root/app/nginx-ldap-auth-daemon.py
+++ b/root/app/nginx-ldap-auth-daemon.py
@@ -214,6 +214,8 @@ class LDAPAuthHandler(AuthHandler):
                 self.log_message('LDAP baseDN is not set!')
                 return
 
+            ldap.set_option(ldap.OPT_X_TLS_REQUIRE_CERT, ldap.OPT_X_TLS_ALLOW)
+            
             ctx['action'] = 'initializing LDAP connection'
             ldap_obj = ldap.initialize(ctx['url']);
 


### PR DESCRIPTION
adds support for self-signed CA certificates

<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]
	

<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo in code or documentation in the README please file an issue and let us sort it out we do not need a PR  --> 
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->


<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

------------------------------

We welcome all PR’s though this doesn’t guarantee it will be accepted.

## Description:
added the line i added

## Benefits of this PR and context:
self-signed CA/certs are extremely common in both the enterprise and SBU sectors, since this isn't web-based, LE is not an option. By default, ldap doesn't support self-signed certs, this addition will allow it to work and very tls trust against the provided CA certificate.

## How Has This Been Tested?
I tested with both STARTTLS and LDAPS successfully using a self-signed certificate for my LDAP server

```
ldap-auth           | 2020-05-09T01:08:17.968088704Z 172.20.0.19 - driz [08/May/2020 21:08:17] Auth OK for user "driz"
ldap-auth           | 2020-05-09T01:08:17.968094439Z 172.20.0.19 - driz [08/May/2020 21:08:17] "GET /auth HTTP/1.0" 200 -
ldap-auth           | 2020-05-09T01:08:17.968100074Z 172.20.0.19 - - [08/May/2020 21:08:17] using username/password from cookie nginxauth
ldap-auth           | 2020-05-09T01:08:17.968105726Z 172.20.0.19 - - [08/May/2020 21:08:17] Trying to dechipher credentials...
ldap-auth           | 2020-05-09T01:08:17.968111852Z 172.20.0.19 - driz [08/May/2020 21:08:17] searching on server "ldaps://192.168.128.8:636" with base dn "cn=Users,dc=mydomain,dc=com" with filter "(sAMAccountName=driz)"
```
logs for STARTTLS look the same in docker logs and im not wiresharking it :)



## Source / References:
https://github.com/nginxinc/nginx-ldap-auth/issues/27
https://www.openldap.org/faq/data/cache/185.html
