### PR TITLE
Allow env variable for fernet key

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Here are some example snippets to help you get started creating a container.
 docker create \
   --name=ldap-auth \
   -e TZ=Europe/London \
+  -e FERNETKEY= `#optional` \
   -p 8888:8888 \
   -p 9000:9000 \
   --restart unless-stopped \
@@ -84,6 +85,7 @@ services:
     container_name: ldap-auth
     environment:
       - TZ=Europe/London
+      - FERNETKEY= #optional
     ports:
       - 8888:8888
       - 9000:9000
@@ -99,6 +101,7 @@ Container images are configured using parameters passed at runtime (such as thos
 | `-p 8888` | the port for ldap auth daemon |
 | `-p 9000` | the port for ldap login page |
 | `-e TZ=Europe/London` | Specify a timezone to use EG Europe/London |
+| `-e FERNETKEY=` | Optionally define a custom fernet key, has to be base64-encoded 32-byte (only needed if container is frequently recreated, or if using multi-node setups, invalidating previous authentications) |
 
 ## Environment variables from files (Docker secrets)
 
@@ -123,7 +126,7 @@ Keep in mind umask is not chmod it subtracts from permissions based on it's valu
 
 - This container itself does not have any settings and it relies on the pertinent information passed through in http headers of incoming requests. Make sure that your webserver is set up with the right config.
 - Here's a sample config: [nginx-ldap-auth.conf](https://github.com/nginxinc/nginx-ldap-auth/blob/master/nginx-ldap-auth.conf).
-- Unlike the upstream project, this image encodes the cookie information with fernet, using a randomly generated key during container creation.
+- Unlike the upstream project, this image encodes the cookie information with fernet, using a randomly generated key during container creation (or optionally user defined).
 - Also unlike the upstream project, this image serves the login page at `/ldaplogin` (as well as `/login`) to prevent clashes with reverse proxied apps that may also use `/login` for their internal auth.
 
 
@@ -197,6 +200,7 @@ Once registered you can define the dockerfile to use with `-f Dockerfile.aarch64
 
 ## Versions
 
+* **21.07.20:** - Add support for optional user defined fernet key.
 * **02.06.20:** - Rebasing to alpine 3.12, serve login page at `/ldaplogin` as well as `/login`, to prevent clashes with reverese proxied apps.
 * **17.05.20:** - Add support for self-signed CA certs.
 * **20.02.20:** - Switch to python3.

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -24,18 +24,24 @@ param_ports:
   - { external_port: "9000", internal_port: "9000", port_desc: "the port for ldap login page" }
 param_usage_include_env: true
 param_env_vars:
-  - { env_var: "TZ", env_value: "Europe/London", desc: "Specify a timezone to use EG Europe/London"}
+  - { env_var: "TZ", env_value: "Europe/London", desc: "Specify a timezone to use EG Europe/London" }
+
+# optional container parameters
+opt_param_usage_include_env: true
+opt_param_env_vars:
+  - { env_var: "FERNETKEY", env_value: "", desc: "Optionally define a custom fernet key, has to be base64-encoded 32-byte (only needed if container is frequently recreated, or if using multi-node setups, invalidating previous authentications)" }
 
 # application setup block
 app_setup_block_enabled: true
 app_setup_block: |
   - This container itself does not have any settings and it relies on the pertinent information passed through in http headers of incoming requests. Make sure that your webserver is set up with the right config.
   - Here's a sample config: [nginx-ldap-auth.conf](https://github.com/nginxinc/nginx-ldap-auth/blob/master/nginx-ldap-auth.conf).
-  - Unlike the upstream project, this image encodes the cookie information with fernet, using a randomly generated key during container creation.
+  - Unlike the upstream project, this image encodes the cookie information with fernet, using a randomly generated key during container creation (or optionally user defined).
   - Also unlike the upstream project, this image serves the login page at `/ldaplogin` (as well as `/login`) to prevent clashes with reverse proxied apps that may also use `/login` for their internal auth.
 
 # changelog
 changelogs:
+  - { date: "21.07.20:", desc: "Add support for optional user defined fernet key." }
   - { date: "02.06.20:", desc: "Rebasing to alpine 3.12, serve login page at `/ldaplogin` as well as `/login`, to prevent clashes with reverese proxied apps." }
   - { date: "17.05.20:", desc: "Add support for self-signed CA certs." }
   - { date: "20.02.20:", desc: "Switch to python3." }

--- a/root/etc/cont-init.d/30-config
+++ b/root/etc/cont-init.d/30-config
@@ -2,7 +2,11 @@
 
 # generate fernet key for ldap if it doesn't exist
 if grep -q 'REPLACEWITHFERNETKEY' /app/ldap-backend-app.py; then
-    if [[ -z "${FERNETKEY}" ]]; then
+    if [ -z "${FERNETKEY}" ]; then
+        KEY=$(python3 /app/fernet-key.py)
+        echo "generated fernet key"
+    elif [ $(openssl base64 -d <<< "${FERNETKEY}" | wc -c) != "32" ]; then
+        echo "FERNETKEY env var is not set to a base64 encoded 32-byte key"
         KEY=$(python3 /app/fernet-key.py)
         echo "generated fernet key"
     else

--- a/root/etc/cont-init.d/30-config
+++ b/root/etc/cont-init.d/30-config
@@ -2,8 +2,14 @@
 
 # generate fernet key for ldap if it doesn't exist
 if grep -q 'REPLACEWITHFERNETKEY' /app/ldap-backend-app.py; then
-    FERNETKEY=$(python3 /app/fernet-key.py)
-    sed -i "s/REPLACEWITHFERNETKEY/${FERNETKEY}/" /app/ldap-backend-app.py
-    sed -i "s/REPLACEWITHFERNETKEY/${FERNETKEY}/" /app/nginx-ldap-auth-daemon.py
-    echo "generated fernet key"
+    if [[ -z "${FERNETKEY}" ]]; then
+        KEY=$(python3 /app/fernet-key.py)
+        echo "generated fernet key"
+    else
+        KEY="b'${FERNETKEY}'"
+        echo "using FERNETKEY from env variable"
+    fi
+    
+    sed -i "s/REPLACEWITHFERNETKEY/${KEY}/" /app/ldap-backend-app.py
+    sed -i "s/REPLACEWITHFERNETKEY/${KEY}/" /app/nginx-ldap-auth-daemon.py    
 fi

--- a/root/etc/cont-init.d/30-config
+++ b/root/etc/cont-init.d/30-config
@@ -5,7 +5,7 @@ if grep -q 'REPLACEWITHFERNETKEY' /app/ldap-backend-app.py; then
     if [ -z "${FERNETKEY}" ]; then
         KEY=$(python3 /app/fernet-key.py)
         echo "generated fernet key"
-    elif ! python3 -c "from cryptography.fernet import Fernet; Fernet(b'${FERNETKEY}').encrypt(b\"my deep dark secret\")" 2>/dev/null; then
+    elif ! python3 -c "from cryptography.fernet import Fernet; Fernet(b'${FERNETKEY}').encrypt(b'my deep dark secret')" 2>/dev/null; then
         echo "FERNETKEY env var is not set to a base64 encoded 32-byte key"
         KEY=$(python3 /app/fernet-key.py)
         echo "generated fernet key"

--- a/root/etc/cont-init.d/30-config
+++ b/root/etc/cont-init.d/30-config
@@ -5,7 +5,7 @@ if grep -q 'REPLACEWITHFERNETKEY' /app/ldap-backend-app.py; then
     if [ -z "${FERNETKEY}" ]; then
         KEY=$(python3 /app/fernet-key.py)
         echo "generated fernet key"
-    elif [ $(openssl base64 -d <<< "${FERNETKEY}" | wc -c) != "32" ]; then
+    elif ! python3 -c "from cryptography.fernet import Fernet; Fernet(b'${FERNETKEY}').encrypt(b\"my deep dark secret\")" 2>/dev/null; then
         echo "FERNETKEY env var is not set to a base64 encoded 32-byte key"
         KEY=$(python3 /app/fernet-key.py)
         echo "generated fernet key"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]
	

<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo in code or documentation in the README please file an issue and let us sort it out we do not need a PR  --> 
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->


<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

------------------------------

We welcome all PR’s though this doesn’t guarantee it will be accepted.

## Description:
add option to send env variable for fernet key

## Benefits of this PR and context:
If running in kubernetes, we need to have the encryption key stored somewhere, or every time the deployment restarts, it will invalidate previous authentications

## How Has This Been Tested?
Tested with and without env variable. Without env variable, the current behaviour continues (generating the key). 

