### PR TITLE
Adding HTTPS support for nginx-ldap-auth-daemon.py

### DIFF
--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -30,6 +30,8 @@ param_env_vars:
 opt_param_usage_include_env: true
 opt_param_env_vars:
   - { env_var: "FERNETKEY", env_value: "", desc: "Optionally define a custom fernet key, has to be base64-encoded 32-byte (only needed if container is frequently recreated, or if using multi-node setups, invalidating previous authentications)" }
+  - { env_var: "CERTFILE", env_value: "", desc: "Point this to a certificate file to enable HTTP over SSL (HTTPS) for the ldap auth daemon" }
+  - { env_var: "KEYFILE", env_value: "", desc: "Point this to the private key file, matching the certificate file referred to in CERTFILE" }
 
 # application setup block
 app_setup_block_enabled: true
@@ -41,6 +43,7 @@ app_setup_block: |
 
 # changelog
 changelogs:
+  - { date: "27.07.20:", desc: "Add support for HTTP over SSL (HTTPS)." }
   - { date: "21.07.20:", desc: "Add support for optional user defined fernet key." }
   - { date: "02.06.20:", desc: "Rebasing to alpine 3.12, serve login page at `/ldaplogin` as well as `/login`, to prevent clashes with reverese proxied apps." }
   - { date: "17.05.20:", desc: "Add support for self-signed CA certs." }

--- a/root/app/nginx-ldap-auth-daemon.py
+++ b/root/app/nginx-ldap-auth-daemon.py
@@ -302,6 +302,9 @@ if __name__ == '__main__':
     group.add_argument('-s', '--starttls', metavar="starttls",
         default="false",
         help=("Establish a STARTTLS protected session (Default: false)"))
+    group.add_argument('--disable-referrals', metavar="disable_referrals",
+        default="false",
+        help=("Sets ldap.OPT_REFERRALS to zero (Default: false)"))
     group.add_argument('-b', metavar="baseDn", dest="basedn", default='',
         help="LDAP base dn (Default: unset)")
     group.add_argument('-D', metavar="bindDn", dest="binddn", default='',
@@ -333,6 +336,10 @@ if __name__ == '__main__':
     }
     LDAPAuthHandler.set_params(auth_params)
     server = AuthHTTPServer(Listen, LDAPAuthHandler)
+    if os.path.isfile(os.environ.get("CERTFILE")) and os.path.isfile(os.environ.get("KEYFILE")):
+        import ssl
+        server.socket = ssl.wrap_socket (server.socket, certfile=os.environ.get("CERTFILE"), keyfile=os.environ.get("KEYFILE"), server_side=True)
+        sys.stdout.write("SSL enabled using certificate file %s and key file %s\n" % (os.environ.get("CERTFILE"), os.environ.get("KEYFILE")))
     signal.signal(signal.SIGINT, exit_handler)
     signal.signal(signal.SIGTERM, exit_handler)
 


### PR DESCRIPTION
Since the traffic between nginx and ldap-auth contains the most sensitive info (passwords) - it is important to set SSL encryption (https) if you want the ldap-auth daemon to be separate from the NGINX server (e.g. run one ldap-auth daemon for multiple nginx servers).

This change will allow setting the paths to a certificate file and its private key in environment variables (CERTFILE and KEYFILE). If provided, then the HTTP server created for the ldap auth daemon will also add SSL.

This was tested for regression (not breaking pre-existing behavior when certificate is not provided) as well as tested to work with a certificate generated by an internal CA. All tests were done on Kubernetes deployment with init container that generated the certificate and saved it in an emptyDir volume.

maintainer edit:
closes #28 