### PR TITLE
Clarify FERNETKEY needs URL-safe base64-encoding, fix sed errors

### DIFF
--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -29,7 +29,7 @@ param_env_vars:
 # optional container parameters
 opt_param_usage_include_env: true
 opt_param_env_vars:
-  - { env_var: "FERNETKEY", env_value: "", desc: "Optionally define a custom fernet key, has to be base64-encoded 32-byte (only needed if container is frequently recreated, or if using multi-node setups, invalidating previous authentications)" }
+  - { env_var: "FERNETKEY", env_value: "", desc: "Optionally define a custom fernet key, has to be URL-safe base64-encoded 32-byte (only needed if container is frequently recreated, or if using multi-node setups, invalidating previous authentications)" }
   - { env_var: "CERTFILE", env_value: "", desc: "Point this to a certificate file to enable HTTP over SSL (HTTPS) for the ldap auth daemon" }
   - { env_var: "KEYFILE", env_value: "", desc: "Point this to the private key file, matching the certificate file referred to in CERTFILE" }
 

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -43,6 +43,7 @@ app_setup_block: |
 
 # changelog
 changelogs:
+  - { date: "05.05.21:", desc: "Fix `FERNETKEY` sed breaking on forward-slash" }
   - { date: "12.02.21:", desc: "Clean up cargo/rust cache." }
   - { date: "10.02.21:", desc: "Rebasing to alpine 3.13." }
   - { date: "08.09.20:", desc: "Set form action correctly." }

--- a/root/etc/cont-init.d/30-config
+++ b/root/etc/cont-init.d/30-config
@@ -13,7 +13,7 @@ if grep -q 'REPLACEWITHFERNETKEY' /app/ldap-backend-app.py; then
         KEY="b'${FERNETKEY}'"
         echo "using FERNETKEY from env variable"
     fi
-    
-    sed -i "s/REPLACEWITHFERNETKEY/${KEY}/" /app/ldap-backend-app.py
-    sed -i "s/REPLACEWITHFERNETKEY/${KEY}/" /app/nginx-ldap-auth-daemon.py    
+
+    sed -i "s#REPLACEWITHFERNETKEY#${KEY}#" /app/ldap-backend-app.py
+    sed -i "s#REPLACEWITHFERNETKEY#${KEY}#" /app/nginx-ldap-auth-daemon.py
 fi


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]


<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo in code or documentation in the README please file an issue and let us sort it out we do not need a PR  -->
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->


<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/docker-ldap-auth/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:
Updates the `FERNETKEY` env var description to clarify _URL-safe_ base64 is expected.

Also changes `30-config` script so `sed` doesn't give a confusing error on non-URL-safe base64-encoding due to a `/`.

## Benefits of this PR and context:
Updates the image documentation so users don't accidentally use non-URL-safe ("standard") base64 and get confusing errors from `sed`. See #41.

## How Has This Been Tested?
I've run `docker build --no-cache --pull -t linuxserver/ldap-auth:latest .` to build the image.

I've then tested starting a container from this image…
- with no `FERNETKEY` env var set. Output includes `generated fernet key`.
- `FERNETKEY=URdT6a0nyUe_4VAPy3kvvP1wDKD0F66Rd9vgl3cheYM=` (URL-safe base64). Output includes `using FERNETKEY from env variable`.
- `FERNETKEY=MaJfhYFV3cvMnIqv1ipyrr0babpe/unSMcSDpg+TlTU=` (including a `/`). Output includes `using FERNETKEY from env variable`.

In all cases the container starts successfully and shows:
```
[services.d] starting services
[services.d] done.
Start listening on 0.0.0.0:8888...
```

## Source / References:
- [cryptography.fernet docs](https://cryptography.io/en/latest/fernet/).