### PR TITLE
Cache the fernet key in the /config volume

### DIFF
--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -15,6 +15,9 @@ available_architectures:
 # container parameters
 param_usage_include_ports: true
 param_container_name: "{{ project_name }}"
+opt_param_usage_include_vols: true
+opt_param_volumes:
+  - { vol_path: "/config", vol_host_path: "</path/to/appdata/config>", desc: "Persistent cache for the fernet key" }
 param_ports:
   - { external_port: "8888", internal_port: "8888", port_desc: "the port for ldap auth daemon" }
   - { external_port: "9000", internal_port: "9000", port_desc: "the port for ldap login page" }
@@ -22,7 +25,7 @@ param_ports:
 # optional container parameters
 opt_param_usage_include_env: true
 opt_param_env_vars:
-  - { env_var: "FERNETKEY", env_value: "", desc: "Optionally define a custom valid fernet key (only needed if container is frequently recreated, or if using multi-node setups, invalidating previous authentications)" }
+  - { env_var: "FERNETKEY", env_value: "", desc: "Optionally define a custom valid fernet key (only needed if the /config volume is not mounted, or if using multi-node setups, invalidating previous authentications)" }
   - { env_var: "CERTFILE", env_value: "", desc: "Optionally point this to a certificate file to enable HTTP over SSL (HTTPS) for the ldap auth daemon" }
   - { env_var: "KEYFILE", env_value: "", desc: "Optionally point this to the private key file, matching the certificate file referred to in CERTFILE" }
 
@@ -33,9 +36,11 @@ app_setup_block: |
   - Here's a sample config: [nginx-ldap-auth.conf](https://github.com/nginxinc/nginx-ldap-auth/blob/master/nginx-ldap-auth.conf).
   - Unlike the upstream project, this image encodes the cookie information with fernet, using a randomly generated key during container creation (or optionally user defined).
   - Also unlike the upstream project, this image serves the login page at `/ldaplogin` (as well as `/login`) to prevent clashes with reverse proxied apps that may also use `/login` for their internal auth.
+  - If the `config` volume is specified, it will be used the cache the generated fernet key across restarts.
 
 # changelog
 changelogs:
+  - { date: "12.11.24:", desc: "Cache the generated fernet key in /config"}
   - { date: "30.06.24:", desc: "Rebase to Alpine 3.20."}
   - { date: "23.12.23:", desc: "Rebase to Alpine 3.19."}
   - { date: "20.06.23:", desc: "Sync upstream changes, including the ability to disable referrals with `X-Ldap-DisableReferrals`." }

--- a/root/etc/s6-overlay/s6-rc.d/init-ldap-config/run
+++ b/root/etc/s6-overlay/s6-rc.d/init-ldap-config/run
@@ -1,20 +1,53 @@
 #!/usr/bin/with-contenv bash
 # shellcheck shell=bash
 
+KEY_FILE=/config/fernet.key
+
+normalize_key () {
+    if [[ -z ${1} || ${1} =~ ^b\'.*\'$ ]]; then
+	echo "${1}"
+    else
+	echo "b'${1}'"
+    fi
+}
+
+test_key () {
+    if [[ -z ${1} ]]; then
+	return 1
+    fi
+    python3 -c "from cryptography.fernet import Fernet; Fernet(${1}).encrypt(b'my deep dark secret')" 2>/dev/null
+}
+
 # generate fernet key for ldap if it doesn't exist
 if grep -q 'REPLACEWITHFERNETKEY' /app/ldap-backend-app.py; then
-    if [[ -z "${FERNETKEY}" ]]; then
-        KEY=$(python3 /app/fernet-key.py)
-        echo "generated fernet key"
-    elif ! python3 -c "from cryptography.fernet import Fernet; Fernet(b'${FERNETKEY}').encrypt(b'my deep dark secret')" 2>/dev/null; then
-        echo "FERNETKEY env var is not set to a base64 encoded 32-byte key"
-        KEY=$(python3 /app/fernet-key.py)
-        echo "generated fernet key"
-    else
-        KEY="b'${FERNETKEY}'"
-        echo "using FERNETKEY from env variable"
+    key=
+    # First check environment variable
+    if [[ -n ${FERNETKEY} ]]; then
+	_key=$(normalize_key "${FERNETKEY}")
+	if test_key "${_key}"; then
+	    key="${_key}"
+            echo "using FERNETKEY from env variable"
+	else
+            echo "FERNETKEY env var is not set to a base64 encoded 32-byte key"
+	fi
+    fi
+    # Second, check for a cached key
+    if [[ -z ${key} && -f ${KEY_FILE} ]]; then
+	_key="$(normalize_key $(cat "${KEY_FILE}"))"
+	if test_key "${_key}"; then
+	    echo "using key from ${KEY_FILE}"
+	    key="${_key}"
+	else
+            echo "${KEY_FILE} does not contain a base64 encoded 32-byte key"
+	fi
+    fi
+    # Finally generate (and save) a new one
+    if [[ -z ${key} ]]; then
+        key=$(python3 /app/fernet-key.py)
+	echo "${key}" > ${KEY_FILE}
+        echo "generated and saved new key"
     fi
 
-    sed -i "s/REPLACEWITHFERNETKEY/${KEY}/" /app/ldap-backend-app.py
-    sed -i "s/REPLACEWITHFERNETKEY/${KEY}/" /app/nginx-ldap-auth-daemon.py
+    sed -i "s/REPLACEWITHFERNETKEY/${key}/" /app/ldap-backend-app.py
+    sed -i "s/REPLACEWITHFERNETKEY/${key}/" /app/nginx-ldap-auth-daemon.py
 fi


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]


<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo (in code, documentation, or the README) please file an issue and let us sort it out. We do not need a PR  -->
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->


<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

------------------------------

 - [X] I have read the [contributing](https://github.com/linuxserver/docker-ldap-auth/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:
<!--- Describe your changes in detail -->

When the fernet key is not provided in an environment variable, cache the generated key in `/config/fernet.key`.  If this is a persistent volume, the key will be reused on container restarts.

This change will also accept a fernet key with or w/o enclosing "b'" and "'".  This avoids confusion as `/app/fernet-key.py` prints it with the byte-string quotes.

## Benefits of this PR and context:
<!--- Please explain why we should accept this PR. If this fixes an outstanding bug, please reference the issue # -->

This is an easier method to preserve the key to prevent issues when the container restarts.  Even on occasional container restarts I was having problems getting the login page w/o clearing cookies.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->

I've been running this change for several days in several docker compose container stacks on x86_64 with a `/config` volume mounted and `FERNETKEY` not defined and a volume mounted.  My gateway errors on the login page have gone away.

I also switched between defining `FERNETKEY` (to one generated by and cached in `/config`) and mounting the `/config` volume to ensure that the same key was being used (by reloading the web page and watching for tracebacks in the container logs).

<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Source / References:
<!--- Please include any forum posts/github links relevant to the PR -->
